### PR TITLE
fixing build

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,5 +1,5 @@
 FROM python:2.7
-ADD requirements.txt /app/test_celery/requirements.txt
+ADD requirements.txt /app/requirements.txt
 ADD ./test_celery/ /app/
 WORKDIR /app/
 RUN pip install -r requirements.txt


### PR DESCRIPTION
requirements.txt in test_celery subdir resulted in pip not being able to
find it. This fixes #1 